### PR TITLE
Update gem to 0.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina-admin-journal (0.4.2)
+    spina-admin-journal (0.5.0)
       babel-transpiler (~> 0.7)
       rails (~> 6.1)
       rails-i18n (~> 6.0)

--- a/app/controllers/spina/admin/journal/articles_controller.rb
+++ b/app/controllers/spina/admin/journal/articles_controller.rb
@@ -19,7 +19,7 @@ module Spina
         CONTENT_PARAMS = Spina.config.locales.inject({}) do |params, locale|
           params.merge("#{locale}_content_attributes": [*PARTS_PARAMS])
         end
-        PARAMS = [:issue_id, :title, :url, :doi, :status, { affiliation_ids: [], **CONTENT_PARAMS }].freeze
+        PARAMS = [:issue_id, :licence_id, :title, :url, :doi, :status, { affiliation_ids: [], **CONTENT_PARAMS }].freeze
         PARTS = %w[abstract attachment].freeze
 
         before_action :set_breadcrumb

--- a/app/controllers/spina/admin/journal/journals_controller.rb
+++ b/app/controllers/spina/admin/journal/journals_controller.rb
@@ -21,7 +21,7 @@ module Spina
           params.merge("#{locale}_content_attributes": [*PARTS_PARAMS])
         end
         PARAMS = [:name, { **CONTENT_PARAMS }].freeze
-        PARTS = %w[logo description].freeze
+        PARTS = %w[journal_abbreviation logo description documents].freeze
 
         before_action :set_journal
         before_action :set_parts_attributes

--- a/app/controllers/spina/admin/journal/licences_controller.rb
+++ b/app/controllers/spina/admin/journal/licences_controller.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Spina
+  module Admin
+    module Journal
+      # Controller for {Licence} records.
+      class LicencesController < ApplicationController
+        PARTS_PARAMS = [
+          :name, :title, :type, :content, :filename, :signed_blob_id, :alt, :attachment_id, :image_id,
+          { images_attributes: %i[filename signed_blob_id image_id alt],
+            content_attributes: [
+              :name, :title,
+              { parts_attributes: [
+                :name, :title, :type, :content, :filename, :signed_blob_id, :alt, :attachment_id, :image_id,
+                { images_attributes: %i[filename signed_blob_id image_id alt] }
+              ] }
+            ] }
+        ].freeze
+        CONTENT_PARAMS = Spina.config.locales.inject({}) do |params, locale|
+          params.merge("#{locale}_content_attributes": [*PARTS_PARAMS])
+        end
+        PARAMS = [:name, :abbreviated_name, { **CONTENT_PARAMS }].freeze
+        PARTS = %w[text url logo].freeze
+
+        before_action :set_breadcrumb
+        before_action :set_licence, only: %i[edit update destroy]
+        before_action :set_parts_attributes, only: %i[new edit]
+        before_action :build_parts, only: %i[edit]
+
+        def index
+          @licences = Licence.sorted
+        end
+
+        def new
+          @licence = Licence.new
+          build_parts
+          add_breadcrumb t('.new')
+        end
+
+        def edit; end
+
+        def create
+          @licence = Licence.new(licence_params)
+          if @licence.save
+            redirect_to admin_journal_licences_path, success: t('.saved')
+          else
+            render :new
+          end
+        end
+
+        def update
+          if @licence.update(licence_params)
+            redirect_to admin_journal_licences_path, success: t('.saved')
+          else
+            render :edit
+          end
+        end
+
+        def destroy
+          @licence.destroy
+          respond_to do |format|
+            format.html do
+              redirect_to admin_journal_licences_path, success: t('.deleted')
+            end
+          end
+        end
+
+        private
+
+        def licence_params
+          params.require(:admin_journal_licence).permit(PARAMS)
+        end
+
+        def set_breadcrumb
+          add_breadcrumb Licence.model_name.human(count: :many), admin_journal_licences_path
+        end
+
+        def set_licence
+          @licence = Licence.find(params[:id])
+          add_breadcrumb @licence.name
+        end
+
+        def set_parts_attributes
+          @parts_attributes = current_theme.parts.select { |part| PARTS.include? part[:name] }
+        end
+
+        def build_parts
+          return unless @parts_attributes.is_a? Array
+
+          @parts = @parts_attributes.collect { |part_attributes| @licence.part(part_attributes) }
+        end
+      end
+    end
+  end
+end

--- a/app/models/spina/admin/journal/article.rb
+++ b/app/models/spina/admin/journal/article.rb
@@ -34,6 +34,9 @@ module Spina
         # @!attribute [rw] issue
         #   @return [Issue] The issue that contains this article.
         belongs_to :issue
+        # @!attribute [rw] licence
+        #   @return [Licence] the licence under which the article is released
+        belongs_to :licence, optional: true
 
         # @!attribute [rw] authorships
         has_many :authorships, dependent: :destroy

--- a/app/models/spina/admin/journal/licence.rb
+++ b/app/models/spina/admin/journal/licence.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Spina
+  module Admin
+    module Journal
+      # A record to hold information about copyright licences.
+      #
+      # Associated with individual articles.
+      #
+      # === Validators
+      # Presence:: {#name}
+      class Licence < ApplicationRecord
+        include AttrJson::Record
+        include AttrJson::NestedAttributes
+        include Spina::Partable
+        include Spina::TranslatedContent
+
+        # @!attribute [rw] name
+        #   @return [String] the name of the licence
+        # @!attribute [rw] abbreviated_name
+        #   @return [String] an optional abbreviated form of the licence name
+        # @!attribute [rw] articles
+        #   @return [ActiveRecord::Relation] articles which use this licence
+        has_many :articles, dependent: :nullify
+
+        validates :name, presence: true
+
+        scope :sorted, -> { order(name: :asc) }
+      end
+    end
+  end
+end

--- a/app/views/layouts/spina/admin/journal/licences.html.haml
+++ b/app/views/layouts/spina/admin/journal/licences.html.haml
@@ -1,0 +1,10 @@
+- content_for :application do
+  %header#header
+    #header_actions
+      = yield :header_actions
+  
+    = render partial: 'spina/admin/shared/breadcrumbs'
+
+  = yield
+
+= render template: 'layouts/spina/admin/admin'

--- a/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
+++ b/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
@@ -1,7 +1,7 @@
 %li{ class: ('active' if %w[articles issues volumes].include? controller_name) }
   = link_to admin_journal_volumes_path do
     = icon 'pages'
-    = ::Spina::Admin::Journal::Journal.instance.name
+    = ::Spina::Admin::Journal::Journal.instance.has_content?(:journal_abbreviation) ? ::Spina::Admin::Journal::Journal.instance.content(:journal_abbreviation) : ::Spina::Admin::Journal::Journal.instance.name
     = icon 'caret-right'
 
     %ul
@@ -12,7 +12,7 @@
       %li{ class: ('active' if %w[articles].include? controller_name) }
         = link_to ::Spina::Admin::Journal::Article.model_name.human(count: :many), admin_journal_articles_path
 
-%li{ class: ('active' if %w[journals authors institutions].include? controller_name) }
+%li{ class: ('active' if %w[journals authors institutions licences].include? controller_name) }
   = link_to edit_admin_journal_journal_path(::Spina::Admin::Journal::Journal.instance.id) do
     = icon 'dots'
     = t 'spina.admin.journal.navigation_title'

--- a/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
+++ b/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
@@ -25,3 +25,5 @@
         = link_to ::Spina::Admin::Journal::Author.model_name.human(count: :many), admin_journal_authors_path
       %li{ class: ('active' if %w[institutions].include? controller_name) }
         = link_to ::Spina::Admin::Journal::Institution.model_name.human(count: :many), admin_journal_institutions_path
+      %li{ class: ('active' if %w[licences].include? controller_name) }
+        = link_to ::Spina::Admin::Journal::Licence.model_name.human(count: :many), admin_journal_licences_path

--- a/app/views/spina/admin/journal/articles/_form_details.html.haml
+++ b/app/views/spina/admin/journal/articles/_form_details.html.haml
@@ -22,6 +22,11 @@
       = f.select :status, Spina::Admin::Journal::Article.statuses.keys.map { |key| [key.humanize, key] }
   .page-form-group
     .page-form-label
+      = Spina::Admin::Journal::Article.human_attribute_name :licence
+    .page-form-content
+      = f.collection_select :licence_id, Spina::Admin::Journal::Licence.sorted, :id, :name, prompt: true
+  .page-form-group
+    .page-form-label
       = ::Spina::Admin::Journal::Author.model_name.human count: :many
     .page-form-content
       .well{ style: 'margin: 0' }

--- a/app/views/spina/admin/journal/licences/_form.html.haml
+++ b/app/views/spina/admin/journal/licences/_form.html.haml
@@ -1,0 +1,43 @@
+- if @licence.errors.any?
+  - content_for :notifications do
+    .notification.notification-danger.animated.fadeInRight
+      = icon 'exclamation'
+      .notification-message
+        = t 'spina.notifications.alert'
+        %small= @licence.errors.full_messages.join('<br />').html_safe
+      = link_to '#', data: { close_notification: true } do
+        = icon 'cross'
+
+= form_for @licence, html: { autocomplete: 'off' } do |f|
+  %header#header
+    = render partial: 'spina/admin/shared/breadcrumbs'
+
+    #header_actions
+      %button.button.button-primary{ type: 'submit', style: 'margin-right: 0', data: { disable_with: t('spina.pages.saving') } }
+        = icon 'check'
+        = t '.save'
+
+      .button{ style: 'margin-right: 0' }= link_to t('spina.cancel'), admin_journal_licences_path
+
+  .page-form
+    .page-form-group
+      .page-form-label
+        = ::Spina::Admin::Journal::Licence.human_attribute_name :name
+      .page-form-content
+        = f.text_field :name
+    .page-form-group
+      .page-form-label
+        = ::Spina::Admin::Journal::Licence.human_attribute_name :abbreviated_name
+      .page-form-content
+        = f.text_field :abbreviated_name
+
+    = f.fields_for :"#{@locale}_content", @parts do |ff|
+      = ff.hidden_field :type, value: ff.object.class.name
+      = ff.hidden_field :title
+      = ff.hidden_field :name
+
+      .page-form-group.page-part{ data: { name: ff.object.name } }
+        = render "spina/admin/parts/#{parts_partial_namespace(ff.object.class.name)}/form", f: ff
+
+  - unless @licence.new_record?
+    .pull-right= link_to t('spina.permanently_delete'), admin_journal_licence_path(@licence), method: :delete, data: { confirm: t('.delete_confirmation', name: @licence.name) }, class: 'button button-link button-danger'

--- a/app/views/spina/admin/journal/licences/_licence.html.haml
+++ b/app/views/spina/admin/journal/licences/_licence.html.haml
@@ -1,0 +1,11 @@
+%tr{ data: { id: licence.id } }
+  %td
+    = link_to licence.name, edit_admin_journal_licence_path(licence)
+  %td
+    = licence.abbreviated_name
+  %td
+    = licence.articles.count
+  %td.nowrap.align-right
+    = link_to edit_admin_journal_licence_path(licence), class: 'button button-link' do
+      = icon 'pencil-outline'
+      = t '.edit'

--- a/app/views/spina/admin/journal/licences/edit.html.haml
+++ b/app/views/spina/admin/journal/licences/edit.html.haml
@@ -1,0 +1,1 @@
+= render 'form'

--- a/app/views/spina/admin/journal/licences/index.html.haml
+++ b/app/views/spina/admin/journal/licences/index.html.haml
@@ -1,0 +1,17 @@
+- content_for(:header_actions) do
+  = link_to new_admin_journal_licence_path, class: 'button button-primary' do
+    = icon 'plus'
+    = t '.new'
+
+.well
+  .table-container
+    %table.table
+      %thead
+        %tr
+          %th= ::Spina::Admin::Journal::Licence.human_attribute_name :name
+          %th= ::Spina::Admin::Journal::Licence.human_attribute_name :abbreviated_name
+          %th= t '.num_articles'
+          %th
+
+      %tbody
+        = render @licences.any? ? @licences : 'empty_list', message: t('.empty')

--- a/app/views/spina/admin/journal/licences/new.html.haml
+++ b/app/views/spina/admin/journal/licences/new.html.haml
@@ -1,0 +1,1 @@
+= render 'form'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,20 @@ en:
             delete_confirmation:
               "Are you sure you want to delete the institution <strong>%{name}</strong>?
               This action is irreversible, and will delete all associated affiliations. Authors will not be deleted."
+        licences:
+          new:
+            new: New licence
+          create:
+            saved: Licence saved.
+          update:
+            saved: Licence saved.
+          destroy:
+            deleted: Licence deleted.
+          form:
+            save: Save licence
+            delete_confirmation:
+              "Are you sure you want to delete the licence <strong>%{name}</strong>?"
+
   activerecord:
     models:
       spina/admin/journal/journal:
@@ -160,6 +174,9 @@ en:
       spina/admin/journal/institution:
         one: Institution
         other: Institutions
+      spina/admin/journal/licence:
+        one: Licence
+        other: Licences
     attributes:
       spina/admin/journal/journal:
         name: Name
@@ -180,6 +197,9 @@ en:
       spina/admin/journal/author:
       spina/admin/journal/institution:
         name: Institution Name
+      spina/admin/journal/licence:
+        name: Licence Name
+        abbreviated_name: Short Name
 
   date:
     formats:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Spina::Engine.routes.draw do
       end
 
       resources :institutions, except: %i[show]
+      resources :licences, except: %i[show]
     end
   end
 end

--- a/db/migrate/20210618090155_create_spina_admin_journal_licences.rb
+++ b/db/migrate/20210618090155_create_spina_admin_journal_licences.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateSpinaAdminJournalLicences < ActiveRecord::Migration[6.1] # :nodoc:
+  def change
+    create_table :spina_admin_journal_licences do |t|
+      t.string :name, null: false, default: 'Unnamed Licence'
+      t.string :abbreviated_name, null: false, default: ''
+      t.jsonb :json_attributes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210618094533_add_licence_to_spina_admin_journal_articles.rb
+++ b/db/migrate/20210618094533_add_licence_to_spina_admin_journal_articles.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddLicenceToSpinaAdminJournalArticles < ActiveRecord::Migration[6.1] # :nodoc:
+  def change
+    add_reference :spina_admin_journal_articles, :licence, null: true,
+                                                           foreign_key: { to_table: :spina_admin_journal_licences }
+  end
+end

--- a/lib/spina/admin/journal/version.rb
+++ b/lib/spina/admin/journal/version.rb
@@ -3,7 +3,7 @@
 module Spina
   module Admin
     module Journal
-      VERSION = '0.4.2'
+      VERSION = '0.5.0'
     end
   end
 end

--- a/test/controllers/spina/admin/journal/licences_controller_test.rb
+++ b/test/controllers/spina/admin/journal/licences_controller_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Spina
+  module Admin
+    module Journal
+      class LicencesControllerTest < ActionDispatch::IntegrationTest
+        include ::Spina::Engine.routes.url_helpers
+
+        setup do
+          @licence = spina_admin_journal_licences :cc_by
+          @licence_without_parts = spina_admin_journal_licences :gplv3
+
+          @user = spina_users :admin
+          post admin_sessions_url, params: { email: @user.email, password: 'password' }
+        end
+
+        test 'should get index' do
+          get admin_journal_licences_url
+          assert_response :success
+        end
+
+        test 'should get new' do
+          get new_admin_journal_licence_url
+          assert_response :success
+        end
+
+        test 'should get edit' do
+          get edit_admin_journal_licence_url(@licence)
+          assert_response :success
+        end
+
+        test 'should create licence' do
+          attributes = {}
+          attributes[:name] = 'New licence'
+          attributes[:abbreviated_name] = 'NL'
+          assert_difference 'Licence.count' do
+            post admin_journal_licences_url, params: { admin_journal_licence: attributes }
+          end
+          assert_redirected_to admin_journal_licences_url
+          assert_equal 'Licence saved.', flash[:success]
+        end
+
+        test 'should not create invalid licence' do
+          attributes = @licence.attributes
+          attributes[:name] = nil
+          assert_no_difference 'Licence.count' do
+            post admin_journal_licences_url, params: { admin_journal_licence: attributes }
+          end
+          assert_response :success
+          assert_not_equal 'Licence saved.', flash[:success]
+        end
+
+        test 'should update licence' do
+          attributes = @licence.attributes
+          attributes[:name] = 'Brand new name'
+          patch admin_journal_licence_url(@licence), params: { admin_journal_licence: attributes }
+          assert_redirected_to admin_journal_licences_url
+          assert_equal 'Licence saved.', flash[:success]
+        end
+
+        test 'should not update invalid licence' do
+          attributes = @licence.attributes
+          attributes[:name] = nil
+          patch admin_journal_licence_url(@licence), params: { admin_journal_licence: attributes }
+          assert_response :success
+          assert_not_equal 'Licence saved.', flash[:success]
+        end
+
+        test 'should destroy licence' do
+          assert_difference 'Licence.count', -1 do
+            delete admin_journal_licence_url(@licence)
+          end
+          assert_redirected_to admin_journal_licences_url
+          assert_equal 'Licence deleted.', flash[:success]
+        end
+
+        test 'should render form when partables missing' do
+          get edit_admin_journal_licence_url(@licence_without_parts)
+          assert_response :success
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/config/initializers/themes/default.rb
+++ b/test/dummy/config/initializers/themes/default.rb
@@ -28,6 +28,10 @@
     name: 'logo',
     title: 'Logo',
     part_type: 'Spina::Parts::Image'
+  }, {
+    name: 'url',
+    title: 'URL',
+    part_type: 'Spina::Parts::Line'
   }]
 
   theme.view_templates = [{

--- a/test/dummy/config/initializers/themes/default.rb
+++ b/test/dummy/config/initializers/themes/default.rb
@@ -5,6 +5,10 @@
   theme.title = 'Default Theme'
 
   theme.parts = [{
+    name: 'name',
+    title: 'Name',
+    part_type: 'Spina::Parts::Line'
+  },{
     name: 'text',
     title: 'Text',
     part_type: 'Spina::Parts::Text'
@@ -32,6 +36,15 @@
     name: 'url',
     title: 'URL',
     part_type: 'Spina::Parts::Line'
+  }, {
+    name: 'documents',
+    title: 'Documents',
+    part_type: 'Spina::Parts::Repeater',
+    parts: %w[name attachment]
+  }, {
+    name: 'journal_abbreviation',
+    title: 'Journal Abbreviation',
+    part_type: 'Spina::Parts::Line',
   }]
 
   theme.view_templates = [{

--- a/test/dummy/config/initializers/themes/default.rb
+++ b/test/dummy/config/initializers/themes/default.rb
@@ -8,7 +8,7 @@
     name: 'name',
     title: 'Name',
     part_type: 'Spina::Parts::Line'
-  },{
+  }, {
     name: 'text',
     title: 'Text',
     part_type: 'Spina::Parts::Text'
@@ -44,7 +44,7 @@
   }, {
     name: 'journal_abbreviation',
     title: 'Journal Abbreviation',
-    part_type: 'Spina::Parts::Line',
+    part_type: 'Spina::Parts::Line'
   }]
 
   theme.view_templates = [{

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_21_121318) do
+ActiveRecord::Schema.define(version: 2021_06_18_094533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,7 +79,9 @@ ActiveRecord::Schema.define(version: 2021_05_21_121318) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "json_attributes"
     t.integer "status", default: 0, null: false
+    t.bigint "licence_id"
     t.index ["issue_id"], name: "index_spina_admin_journal_articles_on_issue_id"
+    t.index ["licence_id"], name: "index_spina_admin_journal_articles_on_licence_id"
   end
 
   create_table "spina_admin_journal_authors", force: :cascade do |t|
@@ -123,6 +125,14 @@ ActiveRecord::Schema.define(version: 2021_05_21_121318) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "json_attributes"
     t.index ["singleton_guard"], name: "index_spina_admin_journal_journals_on_singleton_guard", unique: true
+  end
+
+  create_table "spina_admin_journal_licences", force: :cascade do |t|
+    t.string "name", default: "Unnamed Licence", null: false
+    t.string "abbreviated_name", default: "", null: false
+    t.jsonb "json_attributes"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "spina_admin_journal_parts", force: :cascade do |t|
@@ -363,6 +373,7 @@ ActiveRecord::Schema.define(version: 2021_05_21_121318) do
   add_foreign_key "spina_admin_journal_affiliations", "spina_admin_journal_authors", column: "author_id"
   add_foreign_key "spina_admin_journal_affiliations", "spina_admin_journal_institutions", column: "institution_id"
   add_foreign_key "spina_admin_journal_articles", "spina_admin_journal_issues", column: "issue_id"
+  add_foreign_key "spina_admin_journal_articles", "spina_admin_journal_licences", column: "licence_id"
   add_foreign_key "spina_admin_journal_authorships", "spina_admin_journal_affiliations", column: "affiliation_id"
   add_foreign_key "spina_admin_journal_authorships", "spina_admin_journal_articles", column: "article_id"
   add_foreign_key "spina_admin_journal_issues", "spina_admin_journal_volumes", column: "volume_id"

--- a/test/fixtures/spina/admin/journal/articles.yml
+++ b/test/fixtures/spina/admin/journal/articles.yml
@@ -5,6 +5,7 @@ new_wave:
   doi: link
   issue: vol1_issue1
   status: 0
+  licence: cc_by
   json_attributes:
     en-GB_content:
       - name: abstract

--- a/test/fixtures/spina/admin/journal/licences.yml
+++ b/test/fixtures/spina/admin/journal/licences.yml
@@ -1,0 +1,27 @@
+cc_by:
+  name: Creative Commons Attribution Licence
+  abbreviated_name: CC-BY 4.0
+  json_attributes:
+    en-GB_content:
+      - name: text
+        title: Text
+        type: Spina::Parts::Text
+        content:
+          <div>Do anything you want, so long as you say I did it first.<\/div>
+      - name: url
+        title: URL
+        type: Spina::Parts::Line
+        content: https://example.org/
+
+gplv3:
+  name: GNU Public Licence version 3
+  abbreviated_name: GPLv3
+
+custom:
+  name: My first licence
+  json_attributes:
+    en-GB_content:
+      - name: text
+        title: Text
+        type: Spina::Parts::Text
+        content: <div>Licences are easy!<\/div>

--- a/test/models/spina/admin/journal/article_test.rb
+++ b/test/models/spina/admin/journal/article_test.rb
@@ -21,6 +21,11 @@ module Spina
           assert_nil @new_article.issue
         end
 
+        test 'article has associated licence' do
+          assert_not_nil @article.licence
+          assert_nil @new_article.licence
+        end
+
         test 'should destroy dependent authorships when destroyed' do
           assert_difference 'Authorship.count', -1 * @article.authorships.count do
             @article.destroy

--- a/test/models/spina/admin/journal/licence_test.rb
+++ b/test/models/spina/admin/journal/licence_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Spina
+  module Admin
+    module Journal
+      class LicenceTest < ActiveSupport::TestCase
+        setup do
+          @licence = spina_admin_journal_licences :cc_by
+          @new_licence = Licence.new
+        end
+
+        test 'licence has associated articles' do
+          assert_not_nil @licence.articles
+          assert @new_licence.articles.empty?
+        end
+
+        test 'destroying licence should nullify reference in articles' do
+          article = @licence.articles.first
+          assert_not_nil article.licence
+          assert_empty article.errors[:licence]
+          @licence.destroy
+          article.reload
+          assert_nil article.licence
+          assert_empty article.errors[:licence]
+        end
+
+        test 'name should not be empty' do
+          assert @licence.valid?
+          assert_empty @licence.errors[:name]
+          @licence.name = nil
+          assert @licence.invalid?
+          assert_not_empty @licence.errors[:name]
+        end
+
+        test 'abbreviated_name may be empty' do
+          assert @licence.valid?
+          assert_empty @licence.errors[:abbreviated_name]
+          @licence.abbreviated_name = nil
+          assert @licence.valid?
+          assert_empty @licence.errors[:abbreviated_name]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This update contains the following additions:
* Adds a licence model, associated with articles, which optionally allows a copyright licence to be specified.
* Adds two new parts to the Journal record, `journal_abbreviation`, which allows a short form of the journal name to be displayed e.g. in the admin navigation; and the repeater `documents`, which allows attachments to be linked with the journal.