### PR TITLE
Prepare for second 1.0.0 release candidate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina-admin-journal (1.0.0.rc1)
+    spina-admin-journal (1.0.0.rc2)
       haml-rails (~> 2.0)
       rails (>= 6.0, < 8)
       rails-i18n (>= 6.0, < 8)
@@ -321,7 +321,7 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.27)
       webrick (~> 1.7.0)
-    zeitwerk (2.5.3)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    i18n (1.8.11)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
@@ -268,7 +268,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
-    spina (2.8.0)
+    spina (2.8.1)
       ancestry
       attr_json
       babosa

--- a/app/assets/config/spina_admin_journal_manifest.js
+++ b/app/assets/config/spina_admin_journal_manifest.js
@@ -1,6 +1,2 @@
 //= link spina/admin/journal/application.css
-
-//= link_directory ../javascripts/spina/admin/journal/controllers
-//= link_directory ../javascripts/spina/admin/journal/libraries
-
 //= link spina/admin/journal/application.js

--- a/app/components/spina/admin/journal/form_group_component.html.haml
+++ b/app/components/spina/admin/journal/form_group_component.html.haml
@@ -1,0 +1,4 @@
+.mt-6
+  %label.block.text-sm.leading-5.font-medium.text-gray-700= label
+  .text-gray-400.text-sm= description
+  .mt-1= content

--- a/app/components/spina/admin/journal/form_group_component.rb
+++ b/app/components/spina/admin/journal/form_group_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spina
+  module Admin
+    module Journal
+      # Correctly styles label, description and content of form fields.
+      class FormGroupComponent < ApplicationComponent
+        attr_reader :label, :description
+
+        def initialize(label:, description: '')
+          @label = label
+          @description = description
+        end
+      end
+    end
+  end
+end

--- a/app/components/spina/admin/journal/list_component.html.haml
+++ b/app/components/spina/admin/journal/list_component.html.haml
@@ -1,10 +1,11 @@
-- if sortable?
-  .ml-8.mt-8.text-gray-600.text-sm= t 'spina.admin.journal.sort_info'
-.my-6.md:m-8.bg-white.md:rounded-lg.border-l-0.border-r-0.border.md:border-r.md:border-l.border-gray-200.border-b-0.shadow-sm{ data: { controller: 'sortable' } }
-  = form_with(url: @sort_path, data: { sortable_target: 'form' }) { |f| }
-  %ul{ data: { sortable_target: 'list' } }
-    - if @list_items.any?
-      - @list_items.each do |item|
-        = render Spina::Admin::Journal::ListItemComponent.new(id: item[:id], label: item[:label], path: item[:path], sortable: sortable?)
-    - else
-      = render Spina::Admin::Journal::EmptyListComponent.new
+.my-6.md:m-8
+  - if sortable?
+    .mb-4.text-gray-600.text-sm= t 'spina.admin.journal.sort_info'
+  .bg-white.md:rounded-lg.border-l-0.border-r-0.border.md:border-r.md:border-l.border-gray-200.border-b-0.shadow-sm{ data: { controller: 'sortable' } }
+    = form_with(url: @sort_path, data: { sortable_target: 'form' }) { |f| }
+    %ul{ data: { sortable_target: 'list' } }
+      - if @list_items.any?
+        - @list_items.each do |item|
+          = render Spina::Admin::Journal::ListItemComponent.new(id: item[:id], label: item[:label], path: item[:path], sortable: sortable?)
+      - else
+        = render Spina::Admin::Journal::EmptyListComponent.new

--- a/app/controllers/spina/admin/journal/articles_controller.rb
+++ b/app/controllers/spina/admin/journal/articles_controller.rb
@@ -29,6 +29,8 @@ module Spina
         before_action :set_parts_attributes, only: %i[new edit]
         before_action :build_parts, only: %i[edit]
 
+        admin_section :journal
+
         def index
           @articles = Article.sorted_desc
         end

--- a/app/controllers/spina/admin/journal/authors_controller.rb
+++ b/app/controllers/spina/admin/journal/authors_controller.rb
@@ -9,6 +9,8 @@ module Spina
         before_action :set_tabs, except: %i[index destroy]
         before_action :set_author, only: %i[edit update destroy]
 
+        admin_section :journal_settings
+
         def index
           @authors = Author.all
         end

--- a/app/controllers/spina/admin/journal/authors_controller.rb
+++ b/app/controllers/spina/admin/journal/authors_controller.rb
@@ -62,7 +62,7 @@ module Spina
         private
 
         def author_params
-          params.require(:author).permit(:primary_affiliation_index,
+          params.require(:author).permit(:primary_affiliation_index, :orcid,
                                          affiliations_attributes: %i[id institution_id first_name
                                                                      surname])
         end

--- a/app/controllers/spina/admin/journal/institutions_controller.rb
+++ b/app/controllers/spina/admin/journal/institutions_controller.rb
@@ -9,6 +9,8 @@ module Spina
         before_action :set_tabs, except: %i[index destroy]
         before_action :set_institution, only: %i[edit update destroy]
 
+        admin_section :journal_settings
+
         def index
           @institutions = Institution.all
         end

--- a/app/controllers/spina/admin/journal/issues_controller.rb
+++ b/app/controllers/spina/admin/journal/issues_controller.rb
@@ -30,6 +30,8 @@ module Spina
         before_action :set_parts_attributes, only: %i[new edit]
         before_action :build_parts, only: %i[edit]
 
+        admin_section :journal
+
         def index
           @issues = Issue.sorted_desc
         end

--- a/app/controllers/spina/admin/journal/journals_controller.rb
+++ b/app/controllers/spina/admin/journal/journals_controller.rb
@@ -27,6 +27,8 @@ module Spina
         before_action :set_parts_attributes
         before_action :build_parts, only: %i[edit]
 
+        admin_section :journal_settings
+
         def edit
           add_breadcrumb @journal.name
         end

--- a/app/controllers/spina/admin/journal/licences_controller.rb
+++ b/app/controllers/spina/admin/journal/licences_controller.rb
@@ -27,6 +27,8 @@ module Spina
         before_action :set_parts_attributes, only: %i[new edit]
         before_action :build_parts, only: %i[edit]
 
+        admin_section :journal_settings
+
         def index
           @licences = Licence.sorted
         end

--- a/app/controllers/spina/admin/journal/volumes_controller.rb
+++ b/app/controllers/spina/admin/journal/volumes_controller.rb
@@ -9,6 +9,8 @@ module Spina
         before_action :set_tabs, except: %i[index destroy]
         before_action :set_volume, only: %i[edit destroy]
 
+        admin_section :journal
+
         def index
           @volumes = Volume.sorted_asc
         end

--- a/app/models/spina/admin/journal/author.rb
+++ b/app/models/spina/admin/journal/author.rb
@@ -26,6 +26,7 @@ module Spina
         has_many :articles, through: :affiliations
 
         validate :must_have_one_primary_affiliation
+        validates :orcid, format: { with: /\A((\d{4}-){3}\d{3}(\d|X))?\z/ }
 
         # @!attribute [r] primary_affiliation
         #   @return [ActiveRecord::Relation] The author's primary affiliation.

--- a/app/models/spina/admin/journal/authorship.rb
+++ b/app/models/spina/admin/journal/authorship.rb
@@ -24,9 +24,9 @@ module Spina
         private
 
         def set_default_position
-          return unless self.article.authorships.sorted_within_article.last.present?
+          return if article.authorships.sorted_within_article.last.nil?
 
-          self.position = self.article.authorships.sorted_within_article.last.position + 1
+          self.position = article.authorships.sorted_within_article.last.position + 1
         end
       end
     end

--- a/app/models/spina/admin/journal/authorship.rb
+++ b/app/models/spina/admin/journal/authorship.rb
@@ -16,9 +16,18 @@ module Spina
         # @!attribute [rw] position
         #   @return [Integer] used to order the affiliations for each article
 
+        before_validation :set_default_position, unless: :persisted?
         validates :position, presence: true, uniqueness: { scope: :article_id }
 
         scope :sorted_within_article, -> { order(position: :asc) }
+
+        private
+
+        def set_default_position
+          return unless self.article.authorships.sorted_within_article.last.present?
+
+          self.position = self.article.authorships.sorted_within_article.last.position + 1
+        end
       end
     end
   end

--- a/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
+++ b/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
@@ -1,4 +1,4 @@
-= render Spina::MainNavigation::SubNavComponent.new(:journal_content) do |nav|
+= render Spina::MainNavigation::SubNavComponent.new(:journal) do |nav|
   - nav.icon do
     = heroicon 'document-add', style: :solid, class: 'w-8 h-8 text-white md:mr-3'
     .text-white.font-semibold.hidden{class: 'md:block transform -translate-x-2 ease-in-out duration-300 absolute md:relative opacity-0 transition-all', 'data-navigation-target': 'label'}

--- a/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
+++ b/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
@@ -1,6 +1,6 @@
 = render Spina::MainNavigation::SubNavComponent.new(:journal) do |nav|
   - nav.icon do
-    = heroicon 'document-add', style: :solid, class: 'w-8 h-8 text-white md:mr-3'
+    = heroicon 'document-duplicate', style: :solid, class: 'w-8 h-8 text-white md:mr-3'
     .text-white.font-semibold.hidden{class: 'md:block transform -translate-x-2 ease-in-out duration-300 absolute md:relative opacity-0 transition-all', 'data-navigation-target': 'label'}
       = Spina::Admin::Journal::Journal.instance.name
 
@@ -18,7 +18,7 @@
 
 = render Spina::MainNavigation::SubNavComponent.new(:journal_settings) do |nav|
   - nav.icon do
-    = heroicon 'dots-horizontal', style: :solid, class: 'w-8 h-8 text-white md:mr-3'
+    = heroicon 'view-grid', style: :solid, class: 'w-8 h-8 text-white md:mr-3'
     .text-white.font-semibold.hidden{class: 'md:block transform -translate-x-2 ease-in-out duration-300 absolute md:relative opacity-0 transition-all', 'data-navigation-target': 'label'}
       = t 'spina.admin.journal.navigation_title'
 

--- a/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
+++ b/app/views/spina/admin/hooks/journal/_primary_navigation.html.haml
@@ -2,7 +2,7 @@
   - nav.icon do
     = heroicon 'document-duplicate', style: :solid, class: 'w-8 h-8 text-white md:mr-3'
     .text-white.font-semibold.hidden{class: 'md:block transform -translate-x-2 ease-in-out duration-300 absolute md:relative opacity-0 transition-all', 'data-navigation-target': 'label'}
-      = Spina::Admin::Journal::Journal.instance.name
+      = Spina::Admin::Journal::Journal.instance.has_content?(:journal_abbreviation) ? Spina::Admin::Journal::Journal.instance.content(:journal_abbreviation) : Spina::Admin::Journal::Journal.instance.name
 
   - nav.links do
     = render Spina::MainNavigation::LinkComponent.new(Spina::Admin::Journal::Volume.model_name.human(count: :many),

--- a/app/views/spina/admin/journal/articles/_form.html.haml
+++ b/app/views/spina/admin/journal/articles/_form.html.haml
@@ -25,4 +25,5 @@
   .p-4.md:p-8
     - @tabs.each_with_index do |tab, i|
       %div{ 'data-tabs-target': 'pane', id: tab, hidden: i != 0 }
-        = render "form_#{tab}"
+        .max-w-5xl= render "form_#{tab}"
+

--- a/app/views/spina/admin/journal/articles/_form_authors.html.haml
+++ b/app/views/spina/admin/journal/articles/_form_authors.html.haml
@@ -1,1 +1,2 @@
+.-mt-4.md:-mt-8
 = render Spina::Admin::Journal::AuthorshipsListComponent.new(authorships: @article.authorships.sorted_within_article, sortable: true)

--- a/app/views/spina/admin/journal/articles/_form_details.html.haml
+++ b/app/views/spina/admin/journal/articles/_form_details.html.haml
@@ -1,15 +1,20 @@
 = form_with model: [spina, :admin_journal, @article], id: dom_id(@article), html: { autocomplete: 'off' } do |f|
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Issue.model_name.human(count: :one)) do
-    = f.collection_select :issue_id, ::Spina::Admin::Journal::Issue.sorted_desc, :id, ->(issue) { t '.volume_issue', volume_number: issue.volume.number, issue_number: issue.number }
+    = f.collection_select(:issue_id,
+                          ::Spina::Admin::Journal::Issue.sorted_desc,
+                          :id,
+                          ->(issue) { t '.volume_issue', volume_number: issue.volume.number, issue_number: issue.number },
+                          {},
+                          class: 'form-select')
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:number),
                                             description: t('.unchangeable')) do
-    = f.number_field :number, disabled: true
+    = f.number_field :number, disabled: true, class: 'form-input'
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:title)) do
     = render Spina::Forms::TextFieldComponent.new(f, :title)
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:status)) do
-    = f.select :status, Spina::Admin::Journal::Article.statuses.keys.map { |key| [key.humanize, key] }
+    = f.select :status, Spina::Admin::Journal::Article.statuses.keys.map { |key| [key.humanize, key] }, {}, class: 'form-select'
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:licence)) do
-    = f.collection_select :licence_id, Spina::Admin::Journal::Licence.sorted, :id, :name, prompt: true
+    = f.collection_select :licence_id, Spina::Admin::Journal::Licence.sorted, :id, :name, { prompt: true }, { class: 'form-select' }
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Author.model_name.human(count: :many)) do
     %table.table{ style: 'margin: 0' }
       %tbody.collection-check-boxes

--- a/app/views/spina/admin/journal/articles/_form_details.html.haml
+++ b/app/views/spina/admin/journal/articles/_form_details.html.haml
@@ -1,32 +1,36 @@
 = form_with model: [spina, :admin_journal, @article], id: dom_id(@article), html: { autocomplete: 'off' } do |f|
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Issue.model_name.human(count: :one)) do
+  .-mt-6
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Issue.model_name.human(count: :one)) do
     = f.collection_select(:issue_id,
                           ::Spina::Admin::Journal::Issue.sorted_desc,
                           :id,
                           ->(issue) { t '.volume_issue', volume_number: issue.volume.number, issue_number: issue.number },
                           {},
                           class: 'form-select')
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:number),
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:number),
                                             description: t('.unchangeable')) do
     = f.number_field :number, disabled: true, class: 'form-input'
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:title)) do
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:title)) do
     = render Spina::Forms::TextFieldComponent.new(f, :title)
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:status)) do
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:status)) do
     = f.select :status, Spina::Admin::Journal::Article.statuses.keys.map { |key| [key.humanize, key] }, {}, class: 'form-select'
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:licence)) do
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:licence)) do
     = f.collection_select :licence_id, Spina::Admin::Journal::Licence.sorted, :id, :name, { prompt: true }, { class: 'form-select' }
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Author.model_name.human(count: :many)) do
-    %table.table{ style: 'margin: 0' }
-      %tbody.collection-check-boxes
-        = f.collection_check_boxes :affiliation_ids, Spina::Admin::Journal::Affiliation.sorted, :id, :name do |builder|
-          %tr
-            %td{ style: "padding-left: 16px" }
-              .form-checkbox
-                = builder.check_box
-                = builder.label
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:url)) do
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Author.model_name.human(count: :many)) do
+    %ul.list-none.ml-4
+      = f.collection_check_boxes(:affiliation_ids,
+                                 Spina::Admin::Journal::Affiliation.sorted,
+                                 :id,
+                                 ->(affiliation) { t '.name_institution', name: affiliation.name, institution: affiliation.institution.name },
+                                 {},
+                                 class: 'form-checkbox rounded') do |builder|
+        %li
+          .form-checkbox
+            = builder.check_box
+            %span.text-sm.font-medium.text-gray-600= builder.label
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:url)) do
     = render Spina::Forms::TextFieldComponent.new(f, :url)
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:doi)) do
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:doi)) do
     = render Spina::Forms::TextFieldComponent.new(f, :doi)
 
   = f.fields_for :"#{@locale}_content", @parts do |ff|

--- a/app/views/spina/admin/journal/articles/_form_details.html.haml
+++ b/app/views/spina/admin/journal/articles/_form_details.html.haml
@@ -8,7 +8,7 @@
                           {},
                           class: 'form-select')
   = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:number),
-                                            description: t('.unchangeable')) do
+                                                         description: t('.unchangeable')) do
     = f.number_field :number, disabled: true, class: 'form-input'
   = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:title)) do
     = render Spina::Forms::TextFieldComponent.new(f, :title)
@@ -16,7 +16,8 @@
     = f.select :status, Spina::Admin::Journal::Article.statuses.keys.map { |key| [key.humanize, key] }, {}, class: 'form-select'
   = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Article.human_attribute_name(:licence)) do
     = f.collection_select :licence_id, Spina::Admin::Journal::Licence.sorted, :id, :name, { prompt: true }, { class: 'form-select' }
-  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Author.model_name.human(count: :many)) do
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Author.model_name.human(count: :many),
+                                                         description: t('.affiliation_info')) do
     %ul.list-none.ml-4
       = f.collection_check_boxes(:affiliation_ids,
                                  Spina::Admin::Journal::Affiliation.sorted,

--- a/app/views/spina/admin/journal/authors/_form.html.haml
+++ b/app/views/spina/admin/journal/authors/_form.html.haml
@@ -26,4 +26,4 @@
     = form_with model: [spina, :admin_journal, @author], id: dom_id(@author), html: { autocomplete: 'off' } do |f|
       - @tabs.each_with_index do |tab, i|
         %div{ 'data-tabs-target': 'pane', id: tab, hidden: i != 0 }
-          = render "form_#{tab}", f: f
+          .max-w-5xl= render "form_#{tab}", f: f

--- a/app/views/spina/admin/journal/authors/_form_affiliation.html.haml
+++ b/app/views/spina/admin/journal/authors/_form_affiliation.html.haml
@@ -1,8 +1,9 @@
-= render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:first_name)) do
+.-mt-6
+= render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:first_name)) do
   = render Spina::Forms::TextFieldComponent.new(ff, :first_name)
-= render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:surname)) do
+= render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:surname)) do
   = render Spina::Forms::TextFieldComponent.new(ff, :surname)
-= render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:institution)) do
+= render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:institution)) do
   = ff.collection_select :institution_id, Spina::Admin::Journal::Institution.sorted, :id, :name, {}, class: 'form-select'
-= render Spina::Forms::GroupComponent.new(label: t('.primary'), description: t('.primary_explanation')) do
+= render Spina::Admin::Journal::FormGroupComponent.new(label: t('.primary'), description: t('.primary_explanation')) do
   = radio_button_tag 'author[primary_affiliation_index]', ff.index, ff.object.status == 'primary', class: 'form-radio'

--- a/app/views/spina/admin/journal/authors/_form_affiliation.html.haml
+++ b/app/views/spina/admin/journal/authors/_form_affiliation.html.haml
@@ -1,9 +1,12 @@
-.-mt-6
-= render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:first_name)) do
-  = render Spina::Forms::TextFieldComponent.new(ff, :first_name)
-= render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:surname)) do
-  = render Spina::Forms::TextFieldComponent.new(ff, :surname)
-= render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:institution)) do
-  = ff.collection_select :institution_id, Spina::Admin::Journal::Institution.sorted, :id, :name, {}, class: 'form-select'
-= render Spina::Admin::Journal::FormGroupComponent.new(label: t('.primary'), description: t('.primary_explanation')) do
-  = radio_button_tag 'author[primary_affiliation_index]', ff.index, ff.object.status == 'primary', class: 'form-radio'
+%div{ data: { 'part-id': "#{f.object.object_id}", 'tabs-target': 'pane' }, id: "pane_#{f.object.object_id}" }
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:first_name)) do
+    = render Spina::Forms::TextFieldComponent.new(f, :first_name)
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:surname)) do
+    = render Spina::Forms::TextFieldComponent.new(f, :surname)
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:institution)) do
+    = f.collection_select :institution_id, Spina::Admin::Journal::Institution.sorted, :id, :name, {}, class: 'form-select'
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: t('.primary'), description: t('.primary_explanation')) do
+    = radio_button_tag 'author[primary_affiliation_index]', f.index, f.object.status == 'primary', class: 'form-radio'
+
+  .text-right
+    = button_tag t('spina.ui.delete'), type: :button, class: 'btn btn-default bg-transparent hover:bg-white hover:text-red-500 h-8 px-3 inline-block mt-3', data: { action: 'repeater#removeFields', id: "pane_#{f.object.object_id}" }

--- a/app/views/spina/admin/journal/authors/_form_affiliation.html.haml
+++ b/app/views/spina/admin/journal/authors/_form_affiliation.html.haml
@@ -3,6 +3,6 @@
 = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:surname)) do
   = render Spina::Forms::TextFieldComponent.new(ff, :surname)
 = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Affiliation.human_attribute_name(:institution)) do
-  = ff.collection_select :institution_id, Spina::Admin::Journal::Institution.sorted, :id, :name
-= render Spina::Forms::GroupComponent.new(label: t('.primary')) do
-  = radio_button_tag 'author[primary_affiliation_index]', ff.index, ff.object.status == 'primary'
+  = ff.collection_select :institution_id, Spina::Admin::Journal::Institution.sorted, :id, :name, {}, class: 'form-select'
+= render Spina::Forms::GroupComponent.new(label: t('.primary'), description: t('.primary_explanation')) do
+  = radio_button_tag 'author[primary_affiliation_index]', ff.index, ff.object.status == 'primary', class: 'form-radio'

--- a/app/views/spina/admin/journal/authors/_form_articles.html.haml
+++ b/app/views/spina/admin/journal/authors/_form_articles.html.haml
@@ -1,1 +1,2 @@
+.-mt-4.md:-mt-8
 = render Spina::Admin::Journal::ArticlesListComponent.new(articles: @author.affiliations.reduce([]) { |memo, affiliation| memo << affiliation.articles.to_a }.flatten )

--- a/app/views/spina/admin/journal/authors/_form_details.html.haml
+++ b/app/views/spina/admin/journal/authors/_form_details.html.haml
@@ -1,2 +1,24 @@
-= f.fields_for :affiliations, @author.affiliations do |ff|
-  .well= render 'form_affiliation', ff: ff
+.text-gray-700.text-sm.font-light= t '.explanation'
+.mt-6{ 'data-controller': 'repeater' }
+  %label.block.text-sm.leading-5.font-medium.text-gray-700= Spina::Admin::Journal::Author.human_attribute_name :affiliations
+  .-mt-4.flex.flex-col.md:flex-row{ data: { 'controller': 'tabs', 'tabs-active': 'bg-spina-dark bg-opacity-10 text-gray-900', 'tabs-inactive': 'text-gray-500' }  }
+    .md:w-64.md:pr-6
+
+      -# Fields for new affiliation
+      - new_affiliation = Spina::Admin::Journal::Affiliation.new
+      - fields = f.fields_for(:affiliations, [new_affiliation], child_index: new_affiliation.object_id) { |ff| render('form_affiliation', f: ff) }.gsub('\n', '')
+
+      -# Tabs
+      .pt-6.-ml-3
+        %div{ data: { action: 'exists->tabs#added', 'repeater-target' => 'list', 'tabs-target' => 'list' } }
+          - (f.object.affiliations || []).each.with_index do |affiliation, index|
+            %button.text-gray-500.hover:text-gray-900.rounded-md.px-3.truncate.text-sm.font-medium.flex.items-center.w-full.h-9{ data: { 'action': 'tabs#show', 'pane-id': "pane_#{affiliation.object_id}", 'repeater-target': 'listItem', 'tabs-target': 'button' }, type: 'button' }
+              = affiliation&.name
+        %button.text-gray-400.pl-2.hover:text-gray-900.rounded-md.truncate.text-sm.font-medium.flex.items-center.w-full.h-10{ data: { 'action': 'repeater#addFields', 'child-index': "#{new_affiliation.object_id}", 'fields': fields }, type: 'button' }
+          = heroicon 'plus', style: :solid, class: 'w-6 h-6 mr-1'
+          = t 'spina.ui.new_entry'
+
+    -# Content
+    .flex-1.pl-6.md:pl-0{ 'data-repeater-target': 'content' }
+      = f.fields_for :affiliations do |affiliation_fields|
+        = render 'form_affiliation', f: affiliation_fields

--- a/app/views/spina/admin/journal/authors/_form_details.html.haml
+++ b/app/views/spina/admin/journal/authors/_form_details.html.haml
@@ -22,3 +22,7 @@
     .flex-1.pl-6.md:pl-0{ 'data-repeater-target': 'content' }
       = f.fields_for :affiliations do |affiliation_fields|
         = render 'form_affiliation', f: affiliation_fields
+
+= render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Author.human_attribute_name(:orcid),
+                                                       description: t('.orcid_info')) do
+  = render Spina::Forms::TextFieldComponent.new(f, :orcid)

--- a/app/views/spina/admin/journal/institutions/_form.html.haml
+++ b/app/views/spina/admin/journal/institutions/_form.html.haml
@@ -26,4 +26,4 @@
     = form_with model: [spina, :admin_journal, @institution], id: dom_id(@institution), html: { autocomplete: 'off' } do |f|
       - @tabs.each_with_index do |tab, i|
         %div{ 'data-tabs-target': 'pane', id: tab, hidden: i != 0 }
-          = render "form_#{tab}", f: f
+          .max-w-5xl= render "form_#{tab}", f: f

--- a/app/views/spina/admin/journal/institutions/_form_details.html.haml
+++ b/app/views/spina/admin/journal/institutions/_form_details.html.haml
@@ -1,3 +1,4 @@
-= render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Institution.human_attribute_name(:name)) do
+.-mt-6
+= render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Institution.human_attribute_name(:name)) do
   = render Spina::Forms::TextFieldComponent.new(f, :name)
 

--- a/app/views/spina/admin/journal/institutions/_form_view_affiliations.html.haml
+++ b/app/views/spina/admin/journal/institutions/_form_view_affiliations.html.haml
@@ -1,1 +1,2 @@
+.-mt-4.md:-mt-8
 = render Spina::Admin::Journal::AffiliationsListComponent.new(affiliations: @institution.affiliations.sorted)

--- a/app/views/spina/admin/journal/issues/_form.html.haml
+++ b/app/views/spina/admin/journal/issues/_form.html.haml
@@ -25,5 +25,5 @@
   .p-4.md:p-8
     - @tabs.each_with_index do |tab, i|
       %div{ 'data-tabs-target': 'pane', id: tab, hidden: i != 0 }
-        = render "form_#{tab}"
+        .max-w-5xl.max-w-5xl= render "form_#{tab}"
 

--- a/app/views/spina/admin/journal/issues/_form_articles.html.haml
+++ b/app/views/spina/admin/journal/issues/_form_articles.html.haml
@@ -1,1 +1,2 @@
+.-mt-4.md:-mt-8
 = render Spina::Admin::Journal::ArticlesListComponent.new(articles: @issue.articles, sortable: true)

--- a/app/views/spina/admin/journal/issues/_form_details.html.haml
+++ b/app/views/spina/admin/journal/issues/_form_details.html.haml
@@ -1,13 +1,13 @@
 = form_with model: [spina, :admin_journal, @issue], id: dom_id(@issue), html: { autocomplete: 'off' } do |f|
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Volume.human_attribute_name(:number)) do
-    = f.collection_select :volume_id, ::Spina::Admin::Journal::Volume.sorted_desc, :id, :number
+    = f.collection_select :volume_id, ::Spina::Admin::Journal::Volume.sorted_desc, :id, :number, {}, class: 'form-select'
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:number),
                                             description: t('.issue_unchangeable')) do
-    = f.number_field :number, disabled: true
+    = f.number_field :number, disabled: true, class: 'form-input'
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:title)) do
     = render Spina::Forms::TextFieldComponent.new(f, :title)
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:date)) do
-    = f.date_field :date
+    = f.date_field :date, class: 'form-input'
 
   = f.fields_for :"#{@locale}_content", @parts do |ff|
     = ff.hidden_field :type, value: ff.object.class

--- a/app/views/spina/admin/journal/issues/_form_details.html.haml
+++ b/app/views/spina/admin/journal/issues/_form_details.html.haml
@@ -1,12 +1,13 @@
 = form_with model: [spina, :admin_journal, @issue], id: dom_id(@issue), html: { autocomplete: 'off' } do |f|
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Volume.human_attribute_name(:number)) do
+  .-mt-6
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Volume.human_attribute_name(:number)) do
     = f.collection_select :volume_id, ::Spina::Admin::Journal::Volume.sorted_desc, :id, :number, {}, class: 'form-select'
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:number),
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:number),
                                             description: t('.issue_unchangeable')) do
     = f.number_field :number, disabled: true, class: 'form-input'
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:title)) do
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:title)) do
     = render Spina::Forms::TextFieldComponent.new(f, :title)
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:date)) do
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Issue.human_attribute_name(:date)) do
     = f.date_field :date, class: 'form-input'
 
   = f.fields_for :"#{@locale}_content", @parts do |ff|

--- a/app/views/spina/admin/journal/journals/_form.html.haml
+++ b/app/views/spina/admin/journal/journals/_form.html.haml
@@ -15,7 +15,8 @@
 .p-4.md:p-8
   .max-w-5xl
     = form_with model: [spina, :admin_journal, @journal], id: dom_id(@journal), html: { autocomplete: 'off' } do |f|
-      = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Journal.human_attribute_name(:name)) do
+      .-mt-6
+      = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Journal.human_attribute_name(:name)) do
         = render Spina::Forms::TextFieldComponent.new(f, :name)
 
       = f.fields_for :"#{@locale}_content", @parts do |ff|

--- a/app/views/spina/admin/journal/journals/_form.html.haml
+++ b/app/views/spina/admin/journal/journals/_form.html.haml
@@ -13,13 +13,14 @@
       = t '.save'
 
 .p-4.md:p-8
-  = form_with model: [spina, :admin_journal, @journal], id: dom_id(@journal), html: { autocomplete: 'off' } do |f|
-    = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Journal.human_attribute_name(:name)) do
-      = render Spina::Forms::TextFieldComponent.new(f, :name)
+  .max-w-5xl
+    = form_with model: [spina, :admin_journal, @journal], id: dom_id(@journal), html: { autocomplete: 'off' } do |f|
+      = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Journal.human_attribute_name(:name)) do
+        = render Spina::Forms::TextFieldComponent.new(f, :name)
 
-    = f.fields_for :"#{@locale}_content", @parts do |ff|
-      = ff.hidden_field :type, value: ff.object.class
-      = ff.hidden_field :title
-      = ff.hidden_field :name
+      = f.fields_for :"#{@locale}_content", @parts do |ff|
+        = ff.hidden_field :type, value: ff.object.class
+        = ff.hidden_field :title
+        = ff.hidden_field :name
 
-      = render "spina/admin/parts/#{parts_partial_namespace(ff.object.class.to_s)}/form", f: ff
+        = render "spina/admin/parts/#{parts_partial_namespace(ff.object.class.to_s)}/form", f: ff

--- a/app/views/spina/admin/journal/licences/_form.html.haml
+++ b/app/views/spina/admin/journal/licences/_form.html.haml
@@ -13,16 +13,17 @@
       = t '.save'
 
 .p-4.md:p-8
-  = form_with model: [spina, :admin_journal, @licence], id: dom_id(@licence), html: { autocomplete: 'off' } do |f|
-    = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Licence.human_attribute_name(:name)) do
-      = render Spina::Forms::TextFieldComponent.new(f, :name)
-    = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Licence.human_attribute_name(:abbreviated_name)) do
-      = render Spina::Forms::TextFieldComponent.new(f, :abbreviated_name)
+  .max-w-5xl
+    = form_with model: [spina, :admin_journal, @licence], id: dom_id(@licence), html: { autocomplete: 'off' } do |f|
+      = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Licence.human_attribute_name(:name)) do
+        = render Spina::Forms::TextFieldComponent.new(f, :name)
+      = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Licence.human_attribute_name(:abbreviated_name)) do
+        = render Spina::Forms::TextFieldComponent.new(f, :abbreviated_name)
 
-    = f.fields_for :"#{@locale}_content", @parts do |ff|
-      = ff.hidden_field :type, value: ff.object.class
-      = ff.hidden_field :title
-      = ff.hidden_field :name
+      = f.fields_for :"#{@locale}_content", @parts do |ff|
+        = ff.hidden_field :type, value: ff.object.class
+        = ff.hidden_field :title
+        = ff.hidden_field :name
 
-      = render "spina/admin/parts/#{parts_partial_namespace(ff.object.class.to_s)}/form", f: ff
+        = render "spina/admin/parts/#{parts_partial_namespace(ff.object.class.to_s)}/form", f: ff
 

--- a/app/views/spina/admin/journal/licences/_form.html.haml
+++ b/app/views/spina/admin/journal/licences/_form.html.haml
@@ -15,9 +15,10 @@
 .p-4.md:p-8
   .max-w-5xl
     = form_with model: [spina, :admin_journal, @licence], id: dom_id(@licence), html: { autocomplete: 'off' } do |f|
-      = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Licence.human_attribute_name(:name)) do
+      .-mt-6
+      = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Licence.human_attribute_name(:name)) do
         = render Spina::Forms::TextFieldComponent.new(f, :name)
-      = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Licence.human_attribute_name(:abbreviated_name)) do
+      = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Licence.human_attribute_name(:abbreviated_name)) do
         = render Spina::Forms::TextFieldComponent.new(f, :abbreviated_name)
 
       = f.fields_for :"#{@locale}_content", @parts do |ff|

--- a/app/views/spina/admin/journal/volumes/_form.html.haml
+++ b/app/views/spina/admin/journal/volumes/_form.html.haml
@@ -25,4 +25,4 @@
   .p-4.md:p-8
     - @tabs.each_with_index do |tab, i|
       %div{ 'data-tabs-target': 'pane', id: tab, hidden: i != 0 }
-        = render "form_#{tab}"
+        .max-w-5xl= render "form_#{tab}"

--- a/app/views/spina/admin/journal/volumes/_form_details.html.haml
+++ b/app/views/spina/admin/journal/volumes/_form_details.html.haml
@@ -1,4 +1,5 @@
 = form_with model: [spina, :admin_journal, @volume], id: dom_id(@volume), html: { autocomplete: 'off' } do |f|
-  = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Volume.human_attribute_name(:number),
+  .-mt-6
+  = render Spina::Admin::Journal::FormGroupComponent.new(label: Spina::Admin::Journal::Volume.human_attribute_name(:number),
                                             description: t('.unchangeable')) do
     = f.number_field :number, disabled: true, class: 'form-input'

--- a/app/views/spina/admin/journal/volumes/_form_details.html.haml
+++ b/app/views/spina/admin/journal/volumes/_form_details.html.haml
@@ -1,4 +1,4 @@
 = form_with model: [spina, :admin_journal, @volume], id: dom_id(@volume), html: { autocomplete: 'off' } do |f|
   = render Spina::Forms::GroupComponent.new(label: Spina::Admin::Journal::Volume.human_attribute_name(:number),
                                             description: t('.unchangeable')) do
-    = f.number_field :number, disabled: true
+    = f.number_field :number, disabled: true, class: 'form-input'

--- a/app/views/spina/admin/journal/volumes/_form_issues.html.haml
+++ b/app/views/spina/admin/journal/volumes/_form_issues.html.haml
@@ -1,1 +1,2 @@
+.-mt-4.md:-mt-8
 = render Spina::Admin::Journal::IssuesListComponent.new(issues: @volume.issues, sortable: true)

--- a/app/views/spina/admin/parts/admin/journal/page_ranges/_form.html.haml
+++ b/app/views/spina/admin/parts/admin/journal/page_ranges/_form.html.haml
@@ -1,5 +1,4 @@
-.page-form-label= f.object.title
-.page-form-control
+= render Spina::Admin::Journal::FormGroupComponent.new(label: f.object.title) do
   = f.number_field :first_page, style: 'width: 10%;', class: 'form-input'
   &ndash;
   = f.number_field :last_page, style: 'width: 10%;', class: 'form-input'

--- a/app/views/spina/admin/parts/admin/journal/page_ranges/_form.html.haml
+++ b/app/views/spina/admin/parts/admin/journal/page_ranges/_form.html.haml
@@ -1,6 +1,6 @@
 .page-form-label= f.object.title
 .page-form-control
-  = f.number_field :first_page, style: 'width: 10%;'
+  = f.number_field :first_page, style: 'width: 10%;', class: 'form-input'
   &ndash;
-  = f.number_field :last_page, style: 'width: 10%;'
+  = f.number_field :last_page, style: 'width: 10%;', class: 'form-input'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,9 +143,12 @@ en:
           form_details:
             explanation:
               "An author represents an individual person. A person may change names and/or
-            institutions over time. This is represented in Journal with
-            'affiliations'. An affiliation consists of an author's name and institution at a
-            particular time, or generally within a particular context."
+              institutions over time. This is represented in Journal with
+              'affiliations'. An affiliation consists of an author's name and institution at a
+              particular time, or generally within a particular context."
+            orcid_info:
+              It is highly recommended to provide an ORCID iD for each author. Find out more at
+              orcid.org.
           form_affiliation:
             primary: Primary?
             primary_explanation:
@@ -247,11 +250,18 @@ en:
         position: Position
       spina/admin/journal/author:
         affiliations: Affiliations
+        orcid: ORCID iD
       spina/admin/journal/institution:
         name: Institution Name
       spina/admin/journal/licence:
         name: Licence Name
         abbreviated_name: Short Name
+    errors:
+      models:
+        author:
+          attributes:
+            orcid:
+              invalid: Invalid format for ORCID iD
 
   date:
     formats:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,9 @@ en:
             delete_confirmation: "Are you sure you want to delete the author %{name}?"
           form_affiliation:
             primary: Primary?
+            primary_explanation:
+              If checked, this affiliation will be marked as the author's primary affiliation. An
+              author can only have one primary affiliation.
           form_articles:
             no_articles: There are no articles.
         institutions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,9 @@ en:
         navigation_title: Journal settings
         unnamed_journal: Unnamed journal
         edit: Edit
-        sort_info: "NB: item numbers will only update after you refresh the page."
+        sort_info:
+          "Click and drag items by the handles to reorder. NB: item names will only update after
+          you refresh the page."
         empty_list: There are no items.
         journals:
           index:
@@ -102,6 +104,7 @@ en:
             delete_confirmation: "Are you sure you want to delete '<strong>%{title}</strong>'?"
           form_details:
             volume_issue: "Volume %{volume_number} Issue %{issue_number}"
+            name_institution: "%{name} (%{institution})"
             unchangeable: Article order can be changed in the issue.
           form_authors:
             no_authors: There are no authors.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,9 @@ en:
             volume_issue: "Volume %{volume_number} Issue %{issue_number}"
             name_institution: "%{name} (%{institution})"
             unchangeable: Article order can be changed in the issue.
+            affiliation_info:
+              All affiliations are listed here. You can select multiple affiliations for co-authored
+              articles, but these must be from different authors.
           form_authors:
             no_authors: There are no authors.
             number_of_articles: "# Articles"
@@ -137,11 +140,18 @@ en:
             details: Details
             articles: Articles
             delete_confirmation: "Are you sure you want to delete the author %{name}?"
+          form_details:
+            explanation:
+              "An author represents an individual person. A person may change names and/or
+            institutions over time. This is represented in Journal with
+            'affiliations'. An affiliation consists of an author's name and institution at a
+            particular time, or generally within a particular context."
           form_affiliation:
             primary: Primary?
             primary_explanation:
               If checked, this affiliation will be marked as the author's primary affiliation. An
-              author can only have one primary affiliation.
+              author can only have one primary affiliation. It is the primary affiliation that will
+              be shown most prominently on the author's page.
           form_articles:
             no_articles: There are no articles.
         institutions:
@@ -166,7 +176,8 @@ en:
             view_affiliations: Affiliations
             delete_confirmation:
               "Are you sure you want to delete the institution <strong>%{name}</strong>?
-              This action is irreversible, and will delete all associated affiliations. Authors will not be deleted."
+              This action is irreversible, and will delete all associated affiliations. Authors
+              will not be deleted."
           form_view_affiliations:
             no_affiliations: This institution has no associated affiliations.
             number_of_articles: "# articles"
@@ -235,6 +246,7 @@ en:
       spina/admin/journal/authorship:
         position: Position
       spina/admin/journal/author:
+        affiliations: Affiliations
       spina/admin/journal/institution:
         name: Institution Name
       spina/admin/journal/licence:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,7 @@
 en:
   spina:
+    languages:
+      en-GB: British English
     admin:
       journal:
         navigation_title: Journal settings
@@ -38,6 +40,8 @@ en:
             saved: Volume saved.
           form:
             save: Save
+            details: Details
+            issues: Issues
             delete_confirmation: "Are you sure you want to delete Volume <strong>#%{number}</strong>?"
           form_details:
             unchangeable: The volume number can be changed by clicking 'Change Order' in the index view.
@@ -67,6 +71,8 @@ en:
             deleted: Issue deleted.
           form:
             save: Save issue
+            details: Details
+            articles: Articles
             delete_confirmation: "Are you sure you want to delete Issue <strong>#%{number}</strong>?"
           form_details:
             issue_unchangeable: The issue order can be changed in the 'Volumes' tab.
@@ -91,6 +97,8 @@ en:
             deleted: Article deleted.
           form:
             save: Save article
+            details: Details
+            authors: Authors
             delete_confirmation: "Are you sure you want to delete '<strong>%{title}</strong>'?"
           form_details:
             volume_issue: "Volume %{volume_number} Issue %{issue_number}"
@@ -123,7 +131,8 @@ en:
             sort_error: There was an error when sorting. Check the server logs for more information.
           form:
             save: Save author
-          form_details:
+            details: Details
+            articles: Articles
             delete_confirmation: "Are you sure you want to delete the author %{name}?"
           form_affiliation:
             primary: Primary?
@@ -147,14 +156,17 @@ en:
             deleted: Institution deleted.
           form:
             save: Save institution
-          form_view_affiliations:
-            no_affiliations: This institution has no associated affiliations.
-            number_of_articles: "# articles"
-          form_details:
+            details: Details
+            view_affiliations: Affiliations
             delete_confirmation:
               "Are you sure you want to delete the institution <strong>%{name}</strong>?
               This action is irreversible, and will delete all associated affiliations. Authors will not be deleted."
+          form_view_affiliations:
+            no_affiliations: This institution has no associated affiliations.
+            number_of_articles: "# articles"
         licences:
+          index:
+            new: New licence
           new:
             new: New licence
           create:

--- a/db/migrate/20220130171603_add_orcid_to_spina_admin_journal_author.rb
+++ b/db/migrate/20220130171603_add_orcid_to_spina_admin_journal_author.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrcidToSpinaAdminJournalAuthor < ActiveRecord::Migration[7.0] # :nodoc:
+  def change
+    add_column :spina_admin_journal_authors, :orcid, :string, null: false, default: ''
+  end
+end

--- a/lib/spina/admin/journal/version.rb
+++ b/lib/spina/admin/journal/version.rb
@@ -3,7 +3,7 @@
 module Spina
   module Admin
     module Journal
-      VERSION = '1.0.0.rc1'
+      VERSION = '1.0.0.rc2'
     end
   end
 end

--- a/test/controllers/spina/admin/journal/articles_controller_test.rb
+++ b/test/controllers/spina/admin/journal/articles_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module Spina
   module Admin
     module Journal
-      class ArticlesControllerTest < ActionDispatch::IntegrationTest
+      class ArticlesControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Metrics/ClassLength
         include ::Spina::Engine.routes.url_helpers
 
         setup do

--- a/test/controllers/spina/admin/journal/articles_controller_test.rb
+++ b/test/controllers/spina/admin/journal/articles_controller_test.rb
@@ -46,6 +46,19 @@ module Spina
           assert_equal 'Article saved.', flash[:success]
         end
 
+        test 'should create article with multiple authors' do
+          attributes = {}
+          attributes[:title] = 'New Article'
+          attributes[:number] = 3
+          attributes[:issue_id] = @article.issue_id
+          attributes[:affiliation_ids] = [@article2.affiliations.first.id, @article2.affiliations.last.id]
+          assert_difference 'Article.count' do
+            post admin_journal_articles_url, params: { article: attributes }
+          end
+          assert_redirected_to %r{articles/\d+/edit}
+          assert_equal 'Article saved.', flash[:success]
+        end
+
         test 'should not create invalid article' do
           attributes = @article.attributes
           attributes[:title] = nil
@@ -59,6 +72,14 @@ module Spina
         test 'should update article' do
           attributes = @article.attributes
           attributes[:title] = 'New name'
+          patch admin_journal_article_url(@article), params: { article: attributes }
+          assert_redirected_to edit_admin_journal_article_url(@article)
+          assert_equal 'Article saved.', flash[:success]
+        end
+
+        test 'should update article to have multiple authors' do
+          attributes = @article.attributes
+          attributes[:affiliation_ids] = [@article2.affiliations.first.id, @article2.affiliations.last.id]
           patch admin_journal_article_url(@article), params: { article: attributes }
           assert_redirected_to edit_admin_journal_article_url(@article)
           assert_equal 'Article saved.', flash[:success]

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -47,5 +47,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_26_153728) do
+ActiveRecord::Schema.define(version: 2022_01_30_171603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2021_06_26_153728) do
   create_table "spina_admin_journal_authors", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "orcid", default: "", null: false
   end
 
   create_table "spina_admin_journal_authorships", force: :cascade do |t|

--- a/test/models/spina/admin/journal/author_test.rb
+++ b/test/models/spina/admin/journal/author_test.rb
@@ -51,6 +51,36 @@ module Spina
           invalid_author = Author.new attributes
           assert invalid_author.invalid?
         end
+
+        test 'authorship has a valid orcid' do
+          assert @author.valid?
+          assert_empty @author.errors[:orcid]
+          @author.orcid = '0000-0001-5237-5153'
+          assert @author.valid?
+          assert_empty @author.errors[:orcid]
+          @author.orcid = '0000-0001-5237-515X'
+          assert @author.valid?
+          assert_empty @author.errors[:orcid]
+        end
+
+        test 'orcid should have correct format' do
+          assert @author.valid?
+          assert_empty @author.errors[:orcid]
+          @author.orcid = '0000-00+01-5237-5153'
+          assert @author.invalid?
+          assert_not_empty @author.errors[:orcid]
+          @author.orcid = '0000--5237-5153'
+          assert @author.invalid?
+          assert_not_empty @author.errors[:orcid]
+        end
+
+        test 'orcid may be blank' do
+          assert @author.valid?
+          assert_empty @author.errors[:orcid]
+          @author.orcid = ''
+          assert @author.valid?
+          assert_empty @author.errors[:orcid]
+        end
       end
     end
   end

--- a/test/system/spina/admin/journal/articles_test.rb
+++ b/test/system/spina/admin/journal/articles_test.rb
@@ -23,10 +23,8 @@ module Spina
           assert_text 'New article'
           fill_in 'article_title', with: 'New article'
           select 'Volume 1 Issue 1', from: 'article_issue_id'
-          within '.collection-check-boxes' do
-            @article.affiliations.each do |affiliation|
-              find("label[for=article_affiliation_ids_#{affiliation.id}]").click
-            end
+          @article.affiliations.each do |affiliation|
+            find("label[for=article_affiliation_ids_#{affiliation.id}]").click
           end
 
           # check that authors list is empty

--- a/test/system/spina/admin/journal/institutions_test.rb
+++ b/test/system/spina/admin/journal/institutions_test.rb
@@ -23,7 +23,7 @@ module Spina
           fill_in 'institution_name', with: 'New institution'
 
           # check that affiliations list is empty
-          click_button 'View Affiliations', class: 'bg-transparent'
+          click_button 'Affiliations', class: 'bg-transparent'
           assert_text 'There are no items.'
 
           click_on 'Save institution'

--- a/test/system/spina/admin/journal/issues_test.rb
+++ b/test/system/spina/admin/journal/issues_test.rb
@@ -77,7 +77,6 @@ module Spina
           fill_in 'issue_date', with: Time.zone.today
 
           click_button 'Articles', class: 'bg-transparent'
-          assert_text 'NB: item numbers will only update after you refresh the page.'
 
           # first_handle = find("li[data-id=\"#{@issue.id}\"] .cursor-move")
           # last_handle = find("li[data-id=\"#{@issue2.id}\"] .cursor-move")


### PR DESCRIPTION
This PR does the following:
- [x] Fixes assets manifest.
- [x] Fixes primary navigation.
- [x] Changes the icons used in primary navigation.
- [x]  Adds all missing translations.
- [x] Improves styling of forms.
- [x] Supports authors with multiple affiliations.
- [x] Adds a new field, `orcid`, to `Spina::Admin::Journal::Author`. 

NB this PR contains a new migration!